### PR TITLE
Augmented copy.CopyOrLink to also work recursively

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -8,6 +8,7 @@ import (
 // interface for copying files, directories, or links
 type copyObject interface {
 	copyTo(dst string) error
+	linkTo(dst string) error
 	Path() string
 	Info() os.FileInfo
 }
@@ -49,6 +50,14 @@ func LinkOrCopy(src, dst string) error {
 		return All(src, dst)
 	}
 	return nil
+}
+
+func LinkOrCopyAll(src,dst string) error {
+	obj, err := newObject(src)
+	if err != nil {
+		return err
+	}
+	return obj.linkTo(dst)
 }
 
 // internal function to throw away file close errors in deferred

--- a/directory.go
+++ b/directory.go
@@ -16,7 +16,7 @@ func newDirectory(path string, fi os.FileInfo) directory {
 
 // copyTo recursively copies directories from d.path to dst
 func (d directory) copyTo(dst string) error {
-	// create new directory with source mode
+	// create new directory with source mode matching
 	if err := os.MkdirAll(dst, d.info.Mode()); err != nil {
 		return err
 	}
@@ -42,6 +42,10 @@ func (d directory) copyTo(dst string) error {
 
 	// successful
 	return nil
+}
+
+func (d directory) linkTo(dst string) error {
+	return d.copyTo(dst)
 }
 
 func (d directory) String() string {

--- a/directory.go
+++ b/directory.go
@@ -27,6 +27,12 @@ func (d directory) copyTo(dst string) error {
 		return err
 	}
 
+	// Make sure we *can* copy the children if any
+	if len(children) > 0 && d.info.Mode()&0200 == 0 {
+		if err := os.Chmod(dst,d.info.Mode()|0200);err != nil {
+			return err
+		}
+	}
 	// copy each child recursively
 	for _, child := range children {
 		childSrc := filepath.Join(d.path, child.Name())
@@ -36,6 +42,13 @@ func (d directory) copyTo(dst string) error {
 			return err
 		}
 		if err = obj.copyTo(childDst); err != nil {
+			return err
+		}
+	}
+
+	// Restore the directories modes if we made it writeable
+	if len(children) > 0 && d.info.Mode()&0200 == 0 {
+		if err := os.Chmod(dst,d.info.Mode());err != nil {
 			return err
 		}
 	}

--- a/file.go
+++ b/file.go
@@ -47,6 +47,14 @@ func (f file) copyTo(dst string) error {
 	return err
 }
 
+func (f file) linkTo(dst string) error {
+	if err := os.Link(f.path, dst); err != nil {
+		// link failed, might be a directory, fallback to recursive copy
+		return f.copyTo(dst)
+	}
+	return nil
+}
+
 func (f file) String() string {
 	return "file: " + f.path
 }

--- a/link.go
+++ b/link.go
@@ -20,6 +20,10 @@ func (l link) copyTo(dst string) error {
 	return os.Symlink(src, dst)
 }
 
+func (l link) linkTo(dst string) error {
+	return l.copyTo(dst)
+}
+
 func (l link) String() string {
 	return "link: " + l.path
 }


### PR DESCRIPTION
Now calls to copy.CopyOrLink(dst,src) will recursively copy just
as All does, but all files will be hardlinked if possible.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>