### PR TITLE
Augmented copy.CopyOrLink to also work recursively

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -8,6 +8,7 @@ import (
 // interface for copying files, directories, or links
 type copyObject interface {
 	copyTo(dst string) error
+	linkOrCopyTo(dst string) error
 	Path() string
 	Info() os.FileInfo
 }
@@ -44,11 +45,11 @@ func All(src, dst string) error {
 // you might be copying over partition boundaries where a link will
 // fail.
 func LinkOrCopy(src, dst string) error {
-	if err := os.Link(src, dst); err != nil {
-		// link failed, might be a directory, fallback to recursive copy
-		return All(src, dst)
+	obj, err := newObject(src)
+	if err != nil {
+		return err
 	}
-	return nil
+	return obj.linkOrCopyTo(dst)
 }
 
 // internal function to throw away file close errors in deferred

--- a/directory.go
+++ b/directory.go
@@ -44,6 +44,10 @@ func (d directory) copyTo(dst string) error {
 	return nil
 }
 
+func (d directory) linkOrCopyTo(dst string) error {
+	return d.copyTo(dst)
+}
+
 func (d directory) String() string {
 	return "directory: " + d.path
 }

--- a/file.go
+++ b/file.go
@@ -47,6 +47,14 @@ func (f file) copyTo(dst string) error {
 	return err
 }
 
+func (f file) linkOrCopyTo(dst string) error {
+	if err := os.Link(f.path, dst); err != nil {
+		// link failed, might be a directory, fallback to recursive copy
+		return f.copyTo(dst)
+	}
+	return nil
+}
+
 func (f file) String() string {
 	return "file: " + f.path
 }

--- a/link.go
+++ b/link.go
@@ -20,6 +20,10 @@ func (l link) copyTo(dst string) error {
 	return os.Symlink(src, dst)
 }
 
+func (l link) linkOrCopyTo(dst string) error {
+	return l.copyTo(dst)
+}
+
 func (l link) String() string {
 	return "link: " + l.path
 }


### PR DESCRIPTION
Now calls to copy.CopyOrLink(src,dst) will recursively copy just
as All(src,dst) does, but all files will be hardlinked if possible.