### PR TITLE
Somewhat better fix for readonly directories.

### DIFF
--- a/directory.go
+++ b/directory.go
@@ -17,7 +17,7 @@ func newDirectory(path string, fi os.FileInfo) directory {
 // copyTo recursively copies directories from d.path to dst
 func (d directory) copyTo(dst string) error {
 	// create new directory with source mode
-	if err := os.MkdirAll(dst, d.info.Mode()); err != nil {
+	if err := os.MkdirAll(dst, d.info.Mode()|os.ModePerm); err != nil {
 		return err
 	}
 
@@ -27,12 +27,6 @@ func (d directory) copyTo(dst string) error {
 		return err
 	}
 
-	// Make sure we *can* copy the children if any
-	if len(children) > 0 && d.info.Mode()&0200 == 0 {
-		if err := os.Chmod(dst,d.info.Mode()|0200);err != nil {
-			return err
-		}
-	}
 	// copy each child recursively
 	for _, child := range children {
 		childSrc := filepath.Join(d.path, child.Name())
@@ -46,11 +40,8 @@ func (d directory) copyTo(dst string) error {
 		}
 	}
 
-	// Restore the directories modes if we made it writeable
-	if len(children) > 0 && d.info.Mode()&0200 == 0 {
-		if err := os.Chmod(dst,d.info.Mode());err != nil {
-			return err
-		}
+	if err := os.Chmod(dst, d.info.Mode()); err != nil {
+		return err
 	}
 
 	// successful


### PR DESCRIPTION
The previous approach to readonly files still maintained:

os.MkdirAll(dst, d.info.Mode())

The problem with this is that if dst is a/b/c and the src directory
is readonly... then MkdirAll creates:

a/ - readonly
then tries to create a/b

but as a/ is readonly... fails with a permissions error.

This change switches to:

os.MkdirAll(dst, d.info.Mode()|os.ModePerm)

which basically creates the directory (and any of its ancestors)
with the maximum permissions allowable by the users umask.

Then after all the recursive creating of things we use:

os.MkdirAll(dst, d.info.Mode())

makes sure that the dst directory itself (and not its ancestors created)
incidentally) to the permissions of the original src directory.